### PR TITLE
Test suite: append $abs_top_builddir/tests to $PATH

### DIFF
--- a/tests/test-lib.sh
+++ b/tests/test-lib.sh
@@ -129,7 +129,7 @@ if ! type cat > /dev/null 2> /dev/null; then
     exit 77
 fi
 
-export PATH=$abs_top_builddir/tests:$abs_top_builddir/src:$PATH
+export PATH=$abs_top_builddir/src:$PATH:$abs_top_builddir/tests
 
 checks_succeeded=0
 checks_failed=0


### PR DESCRIPTION
There are scripts chown and chmod in $abs_top_builddir/tests.
We don't want chmod(1) and chown(1) be replaced by them.

Signed-off-by: Yan, Zheng zyan@redhat.com
