### PR TITLE
Some build script clean-ups

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1,2 +1,9 @@
-#!/bin/sh -ex
-exec autoreconf -f -i
+#!/bin/sh -e
+
+echo "Running autoreconf..."
+autoreconf -f -i
+
+echo
+echo "Proceed by configuring with:"
+echo "    ./configure"
+echo

--- a/configure.ac
+++ b/configure.ac
@@ -4,7 +4,6 @@ AC_INIT([richacl],
 AC_CONFIG_AUX_DIR([build-aux])
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_HEADER([include/config.h])
-#AC_PREFIX_DEFAULT(/usr)
 
 AM_INIT_AUTOMAKE([-Wall foreign 1.11 dist-xz subdir-objects])
 AM_SILENT_RULES([yes])
@@ -41,3 +40,8 @@ AC_CONFIG_FILES([
 	Makefile
 ])
 AC_OUTPUT
+
+echo
+echo "Proceed with compilation and install by running:"
+echo "    make && make install"
+echo


### PR DESCRIPTION
```
* Use user-friendly messages in autogen script rather
  than running in debug mode with -x.
* We don't have a hard requirement to run autoreconf
  with `exec`. So removing `exec` from autogen script.
* Get rid of commented out usage of AC_PREFIX_DEFAULT
  from configure.ac.
```

Signed-off-by: Anoop C S anoopcs@redhat.com
